### PR TITLE
read incoming message only if it's ours

### DIFF
--- a/src/main/java/org/mineacademy/bfo/bungee/BungeeListener.java
+++ b/src/main/java/org/mineacademy/bfo/bungee/BungeeListener.java
@@ -181,9 +181,9 @@ public abstract class BungeeListener implements Listener {
 			}
 
 			for (final BungeeListener listener : registeredListeners) {
-				final IncomingMessage message = new IncomingMessage(channelName, event.getData());
 
 				if (channelName.equals(listener.getChannel())) {
+					final IncomingMessage message = new IncomingMessage(channelName, event.getData());
 					listener.sender = (Server) sender;
 					listener.receiver = receiver;
 					listener.data = event.getData();


### PR DESCRIPTION
Don't attempt to read incoming message, in the process making assumptions about data content, until we're sure the message was meant for us.

One line change, no offense taken if rejected.  Location highlighted in https://github.com/kangarko/ChatControl-Red/issues/2164#issue-1414519567, and appears accurate based on what IncomingMessage.java#L99 is doing.  Should resolve CCR 2164 / bungee side of CCR 2151.